### PR TITLE
move bucket config to post-deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./bin/grax.sh
+web: ./grax

--- a/bin/grax.sh
+++ b/bin/grax.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-./graxctl migrate 
-./graxctl secrets -force "{\"Provider\":\"aws\",\"Type\":\"storage\",\"Name\":\"StorageSecret\",\"Data\":{\"access_key_id\":\"$S3_AWS_ACCESS_KEY_ID\",\"provider\":\"aws\",\"region\":\"$S3_AWS_REGION\",\"s3_bucket\":\"$S3_BUCKET_NAME\",\"secret_access_key\":\"$S3_AWS_SECRET_ACCESS_KEY\"}}"
-
-./grax

--- a/bin/post-deploy.sh
+++ b/bin/post-deploy.sh
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+./graxctl migrate
+./graxctl secrets -force "{\"Provider\":\"aws\",\"Type\":\"storage\",\"Name\":\"StorageSecret\",\"Data\":{\"access_key_id\":\"$S3_AWS_ACCESS_KEY_ID\",\"provider\":\"aws\",\"region\":\"$S3_AWS_REGION\",\"s3_bucket\":\"$S3_BUCKET_NAME\",\"secret_access_key\":\"$S3_AWS_SECRET_ACCESS_KEY\"}}"
+
 curl --max-time 1800 -X POST $GRAX_ADMIN_API_URL/configure-datalake \
   --data-urlencode bucket_name=$S3_BUCKET_NAME \
   --data-urlencode bucket_region=$S3_AWS_REGION \


### PR DESCRIPTION
Instead of setting bucket credentials on app boot up, set them once at the beginning and leave it in the user's hands if things change.

Could in theory add support for bucketeer creds changing.